### PR TITLE
Support Google Fonts containing a space

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ module.exports = {
     message: "🚧 Host me on your domain while you build your new Gatsby site! (or keep me longer, that's fine too) 👷",
     pattern: "Seigaiha",
     color: "#4c4c4c",
-    titleFont: "Lobster",
+    titleFont: "Playfair+Display",
     messageFont: "Montserrat",
     social: ["https://github.com/robinmetral/gatsby-starter-under-construction", "https://twitter.com/robinmetral"],
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ module.exports = {
     message: "🚧 Host me on your domain while you build your new Gatsby site! (or keep me longer, that's fine too) 👷",
     pattern: "Seigaiha",
     color: "#4c4c4c",
-    titleFont: "Playfair+Display",
+    titleFont: "Playfair Display",
     messageFont: "Montserrat",
     social: ["https://github.com/robinmetral/gatsby-starter-under-construction", "https://twitter.com/robinmetral"],
   },


### PR DESCRIPTION
Fixes #5 

Solution: just use a space in `gatsby-config.js` instead of trying to use `+` or `%20` :100: 